### PR TITLE
Add better font for invitation ampersand

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@babel/core": "^7.15.5",
     "@babel/preset-env": "^7.15.6",
+    "@fontsource/allison": "^4.5.1",
     "@fontsource/pinyon-script": "^4.5.0",
     "daisyui": "^1.14.0",
     "firebase": "^8.6.2",

--- a/web/shared/invitation.tsx
+++ b/web/shared/invitation.tsx
@@ -17,7 +17,7 @@ export function Invitation({ family_name, id }: InvitationProps) {
     </div>
     <div className="transform -skew-y-12 text-6xl font-pinyon-script flex flex-col items-center">
       <p className="">Brij</p>
-      <p className="font-sans">{'&'}</p>
+      <p className="font-allison mt-3">{'&'}</p>
       <p className="text-7xl">Miranda</p>
     </div>
     <div className="w-full flex flex-col items-end mt-24">

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -2,6 +2,7 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 @import "@fontsource/pinyon-script";
+@import "@fontsource/allison";
 
 /* custom styles */
 h1 {
@@ -48,6 +49,10 @@ a {
 
 .font-pinyon-script {
   font-family: "Pinyon Script";
+}
+
+.font-allison {
+  font-family: 'Allison';
 }
 
 .page-break-avoid {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1168,6 +1168,11 @@
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.5.1.tgz#a64d1af3c62e3bb89576ec58af880980a562bf4e"
   integrity sha512-dZMzN0uAjwJXWYYAcnxIwXqRTZw3o14hGe7O6uhwjD1ZQWPVYA5lASgnNskEBra0knVBsOXB4KXg+HnlKewN/A==
 
+"@fontsource/allison@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@fontsource/allison/-/allison-4.5.1.tgz#8ee6984c74c10588dbe9165f159c2a7656fb0ad5"
+  integrity sha512-iR7rI62l1Ewv2pftSF17goA+h+QE+59yVhKKruWsSVHIVyzBjWo4MOBTZDrGmHmL/B62Q3rlbYE8m84iX5Kc+w==
+
 "@fontsource/pinyon-script@^4.5.0":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@fontsource/pinyon-script/-/pinyon-script-4.5.0.tgz#48f808b99e78320b9ead341ced69ae383ac5e696"


### PR DESCRIPTION
That font doesn't have an ampersand, so this PR adds another font-specifically for the ampersand

## Before
![image](https://user-images.githubusercontent.com/11782590/134895105-e96b7527-37c3-4d1a-9edc-d95f97ebdaef.png)

## After
![image](https://user-images.githubusercontent.com/11782590/134895029-7ff25627-5765-451f-8b69-79ec0239337e.png)
